### PR TITLE
setup automated Container builds

### DIFF
--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -1,0 +1,33 @@
+name: Podman build
+
+on:
+  push:
+      branches:
+        - master
+        - TRG-ImageProcessing_Clean
+
+env:
+  REGISTRY_USER: treeringgenomics
+  IMAGE_REGISTRY: quay.io
+  REGISTRY_PASSWORD: ${{ secrets.QUAY_PASSWORD }}
+
+jobs:
+  push_to_registry:
+    name: Container
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v2
+
+      - name: Log in to quay.io
+        uses: redhat-actions/podman-login@v1
+        with:
+          username: ${{ env.REGISTRY_USER }}
+          password: ${{ env.REGISTRY_PASSWORD }}
+          registry: ${{ env.IMAGE_REGISTRY }}
+
+      - name: Build container
+        run: podman build --format docker --tag treeringgenomics/image-processing CoreProcessingPipelineScripts/CNN/Mask_RCNN
+
+      - name: Push container
+        run: podman push treeringgenomics/image-processing docker://quay.io/treeringgenomics/image-processing:${GITHUB_REF##*/}

--- a/CoreProcessingPipelineScripts/CNN/Mask_RCNN/Dockerfile
+++ b/CoreProcessingPipelineScripts/CNN/Mask_RCNN/Dockerfile
@@ -1,10 +1,16 @@
-FROM mambaorg/micromamba:0.19.1
+FROM mambaorg/micromamba:0.20.0
 
-COPY . /home/micromamba/
+COPY . /home/mambauser/
 
-RUN micromamba install -y -n base -f /home/micromamba/environment.yml && micromamba clean -a
+WORKDIR /home/mambauser
 
-ENV PATH "/home/micromamba/postprocessing:$MAMBA_ROOT_PREFIX/bin:$PATH"
-ENV PYTHONPATH "/home/micromamba:$PYTHONPATH"
+RUN micromamba install -y -n base wget -f /home/mambauser/environment.yml && micromamba clean -y -a
 
-ENTRYPOINT ["postprocessingCracksRings.py"]
+ARG MAMBA_DOCKERFILE_ACTIVATE=1
+
+RUN wget https://data.swarts.gmi.oeaw.ac.at/treeringcrackscomb2_onlycracks20210121T2224/mask_rcnn_treeringcrackscomb2_onlycracks_0522.h5 && wget https://data.swarts.gmi.oeaw.ac.at/treeringcrackscomb2_onlyring20210121T1457/mask_rcnn_treeringcrackscomb2_onlyring_0186.h5
+
+ENV PATH "/home/mambauser/postprocessing:$MAMBA_ROOT_PREFIX/bin:$PATH"
+ENV PYTHONPATH "/home/mambauser:$PYTHONPATH"
+
+ENTRYPOINT ["postprocessingCracksRings.py", "--weightRing", "/home/mambauser/mask_rcnn_treeringcrackscomb2_onlyring_0186.h5", "--weightCrack", "/home/mambauser/mask_rcnn_treeringcrackscomb2_onlycracks_0522.h5"]


### PR DESCRIPTION
Hi there,

this adds a bit of automation which will build and push Docker images when there are changes to the repository. For now, it is enabled for the `master` and `TRG-ImageProcessing_Clean` branches. Once this is merged, it *should* start building and pushing them [here](https://quay.io/repository/treeringgenomics/image-processing).

I also added the network weights to the container image and changed its entrypoint so that it should use them by default.
Please test if it works as expected.